### PR TITLE
Naprawa kontaktu/ramówki Tyfloradia + uproszczenie opcji kontaktu

### DIFF
--- a/src/controller.cs
+++ b/src/controller.cs
@@ -342,7 +342,7 @@ public void ContactRadioText() {
 (bool available, string title, string meeting) = Podcasts.GetRadioContactInfo();
 if(available) {
 wnd_contact = new ContactRadioWindow(this, title);
-wnd_contact.ShowDialog(wnd);
+wnd_contact.ShowDialog(wnd_radio!=null ? wnd_radio : wnd);
 } else
 MessageBox.Show("W tej chwili możliwość kontaktu jest wyłączona, możliwe, że nie trwa teraz żadna audycja interaktywna lub prowadzący nie umożliwił jeszcze komunikacji.", "Kontakt niemożliwy", MessageBoxButtons.OK, MessageBoxIcon.Error);
 }

--- a/src/model.cs
+++ b/src/model.cs
@@ -11,6 +11,7 @@ using System.Globalization;
 using System.Data;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text;
@@ -83,6 +84,7 @@ hch.Proxy = null;
 hch.UseProxy = false;
 apiClient = new HttpClient(hch);
 apiClient.BaseAddress = new Uri(url);
+apiClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Tyflopodcast", Program.version));
 }
 
 private static string HTMLToText(String source) {

--- a/src/view_contactradio.cs
+++ b/src/view_contactradio.cs
@@ -63,6 +63,7 @@ btn_cancel = new Button();
 btn_cancel.Text = "Anuluj";
 btn_cancel.Size = new Size(320, 60);
 btn_cancel.Location = new Point(345, 410);
+btn_cancel.Click += (sender, e) => this.Close();
 this.Controls.Add(btn_cancel);
 
 this.CancelButton = btn_cancel;

--- a/src/view_radio.cs
+++ b/src/view_radio.cs
@@ -60,10 +60,10 @@ btn_play.Click += (sender, e) => controller.TogglePlayback();
 this.Controls.Add(btn_play);
 
 btn_contact = new Button();
-btn_contact.Text = "&Napisz lub zadzwoń do Tyfloradia";
+btn_contact.Text = "&Napisz do Tyfloradia";
 btn_contact.Size = new Size(100, 80);
 btn_contact.Location = new Point(140, 70);
-btn_contact.Click += (sender, e) => controller.ContactRadio();
+btn_contact.Click += (sender, e) => controller.ContactRadioText();
 this.Controls.Add(btn_contact);
 
 btn_close = new Button();

--- a/tyflopodcast.csproj
+++ b/tyflopodcast.csproj
@@ -4,6 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,8 +15,13 @@
 
 <ItemGroup>
   <Reference Include="Bass.NET">
-    <HintPath>lib\core\Bass.NET.dll</HintPath>
+    <HintPath>lib\Bass.Net.dll</HintPath>
   </Reference>
 </ItemGroup>
+
+  <ItemGroup>
+    <None Include="lib32\**\*" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+    <None Include="lib64\**\*" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Ten PR naprawia problem z brakiem ramówki i kontaktu z Tyfloradiem w aplikacji.

Zmiany:
- Dodany nagłówek User-Agent do zapytań wykonywanych przez HttpClient (serwer kontaktowy potrafi zwracać 403 przy braku UA).
- W oknie Tyfloradia przycisk kontaktu to teraz tylko "Napisz do Tyfloradia" i od razu otwiera formularz tekstowy (opcje dzwonienia nie są już potrzebne).
- Drobna poprawka UX: "Anuluj" w formularzu kontaktu zamyka okno.
- Przy okazji: poprawiony HintPath do Bass.Net.dll w .csproj oraz kopiowanie lib32/lib64 do output/publish.