### PR TITLE
feat: wznawianie odtwarzania + szybki seek przez HTTP Range

### DIFF
--- a/src/model.cs
+++ b/src/model.cs
@@ -61,6 +61,10 @@ public static List<Bookmark> bookmarks;
 
 public static List<int> likes;
 
+private static Dictionary<string, float> resumePositions;
+
+private static readonly object internalDataLock = new object();
+
 public const String url = "http://tyflopodcast.net";
 public const String jsonurl = "http://tyflopodcast.net/wp-json/wp/v2";
 public const String contacturl = "http://kontakt.tyflopodcast.net/json.php";
@@ -207,11 +211,13 @@ private static readonly byte[] MagicInternalNumber = {0xa4, 0x87, 0x42, 0x3f, 0x
 private static bool LoadInternal() {
 string datadir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)+"\\tyflopodcast";
 System.IO.Directory.CreateDirectory(datadir);
-likes = new List<int>();
-bookmarks = new List<Bookmark>();
-if(!File.Exists(datadir+"\\internal.dat")) return false;
 try {
-using (BinaryReader br = new BinaryReader(File.Open(datadir+"\\internal.dat", FileMode.Open))) {
+lock(internalDataLock) {
+	likes = new List<int>();
+	bookmarks = new List<Bookmark>();
+	resumePositions = new Dictionary<string, float>(StringComparer.OrdinalIgnoreCase);
+	if(!File.Exists(datadir+"\\internal.dat")) return false;
+	using (BinaryReader br = new BinaryReader(File.Open(datadir+"\\internal.dat", FileMode.Open))) {
 for(int i=0; i<MagicInternalNumber.Count(); ++i)
 if(br.ReadByte() != MagicInternalNumber[i]) return false;
 int cnt_likes = br.ReadInt32();
@@ -224,15 +230,27 @@ b.name = br.ReadString();
 b.time = br.ReadSingle();
 bookmarks.Add(b);
 }
+
+if(br.BaseStream.Position < br.BaseStream.Length) {
+try {
+int cnt_resume = br.ReadInt32();
+for(int i=0; i<cnt_resume; ++i) {
+string key = br.ReadString();
+float position = br.ReadSingle();
+if(string.IsNullOrEmpty(key) || position < 0) continue;
+resumePositions[key] = position;
 }
-}
+	} catch(EndOfStreamException) {
+	}
+	}
+	}
+	}
+	}
 catch {return false;}
 return true;
 }
 
-private static bool SaveInternal() {
-string datadir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)+"\\tyflopodcast";
-System.IO.Directory.CreateDirectory(datadir);
+private static bool SaveInternalLocked(string datadir) {
 try {
 using (BinaryWriter bw = new BinaryWriter(File.Open(datadir+"\\internal.dat", FileMode.Create))) {
 for(int i=0; i<MagicInternalNumber.Count(); ++i)
@@ -245,11 +263,28 @@ bw.Write(b.podcast);
 bw.Write(b.name);
 bw.Write(b.time);
 }
-}
-}
+	if(resumePositions==null) resumePositions = new Dictionary<string, float>(StringComparer.OrdinalIgnoreCase);
+	bw.Write(resumePositions.Count());
+	foreach(var kv in resumePositions) {
+	bw.Write(kv.Key);
+	bw.Write(kv.Value);
+	}
+	}
+	}
 catch {return false;}
 return true;
 }
+
+private static bool SaveInternal() {
+string datadir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)+"\\tyflopodcast";
+System.IO.Directory.CreateDirectory(datadir);
+	lock(internalDataLock) {
+	if(likes==null) likes = new List<int>();
+	if(bookmarks==null) bookmarks = new List<Bookmark>();
+	if(resumePositions==null) resumePositions = new Dictionary<string, float>(StringComparer.OrdinalIgnoreCase);
+	return SaveInternalLocked(datadir);
+	}
+	}
 
 private static bool LoadLocalDB() {
 LoadInternal();
@@ -478,16 +513,26 @@ return (null,null);
 }
 
 public static void LikePodcast(Podcast podcast) {
+string datadir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)+"\\tyflopodcast";
+System.IO.Directory.CreateDirectory(datadir);
+lock(internalDataLock) {
+if(likes==null) likes = new List<int>();
 if(!likes.Contains(podcast.id)) {
 likes.Add(podcast.id);
-SaveInternal();
+SaveInternalLocked(datadir);
+}
 }
 }
 
 public static void DislikePodcast(Podcast podcast) {
+string datadir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)+"\\tyflopodcast";
+System.IO.Directory.CreateDirectory(datadir);
+lock(internalDataLock) {
+if(likes==null) likes = new List<int>();
 if(likes.Contains(podcast.id)) {
 likes.Remove(podcast.id);
-SaveInternal();
+SaveInternalLocked(datadir);
+}
 }
 }
 
@@ -510,13 +555,67 @@ var b = new Bookmark();
 b.podcast=podcast.id;
 b.time=time;
 b.name=name;
+string datadir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)+"\\tyflopodcast";
+System.IO.Directory.CreateDirectory(datadir);
+lock(internalDataLock) {
+if(bookmarks==null) bookmarks = new List<Bookmark>();
 bookmarks.Add(b);
-SaveInternal();
+SaveInternalLocked(datadir);
+}
 }
 
 public static void DeleteBookmark(Bookmark bookmark) {
+string datadir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)+"\\tyflopodcast";
+System.IO.Directory.CreateDirectory(datadir);
+lock(internalDataLock) {
+if(bookmarks==null) bookmarks = new List<Bookmark>();
 bookmarks.Remove(bookmark);
-SaveInternal();
+SaveInternalLocked(datadir);
+}
+}
+
+public static string GetResumeKeyForPodcast(int podcastId) {
+if(podcastId<=0) return null;
+return "p:"+podcastId.ToString();
+}
+
+public static string GetResumeKeyForFile(string filePath) {
+if(string.IsNullOrWhiteSpace(filePath)) return null;
+try {
+filePath = Path.GetFullPath(filePath);
+} catch {
+}
+return "f:"+filePath.Trim();
+}
+
+public static float GetResumePosition(string key) {
+if(string.IsNullOrWhiteSpace(key)) return 0;
+lock(internalDataLock) {
+if(resumePositions==null) resumePositions = new Dictionary<string, float>(StringComparer.OrdinalIgnoreCase);
+if(resumePositions.TryGetValue(key, out float position)) return position;
+return 0;
+}
+}
+
+public static void SetResumePosition(string key, float position) {
+if(string.IsNullOrWhiteSpace(key) || position<0) return;
+string datadir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)+"\\tyflopodcast";
+System.IO.Directory.CreateDirectory(datadir);
+lock(internalDataLock) {
+if(resumePositions==null) resumePositions = new Dictionary<string, float>(StringComparer.OrdinalIgnoreCase);
+resumePositions[key]=position;
+SaveInternalLocked(datadir);
+}
+}
+
+public static void ClearResumePosition(string key) {
+if(string.IsNullOrWhiteSpace(key)) return;
+string datadir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)+"\\tyflopodcast";
+System.IO.Directory.CreateDirectory(datadir);
+lock(internalDataLock) {
+if(resumePositions==null) resumePositions = new Dictionary<string, float>(StringComparer.OrdinalIgnoreCase);
+if(resumePositions.Remove(key)) SaveInternalLocked(datadir);
+}
 }
 }
 }

--- a/src/mp3_seek.cs
+++ b/src/mp3_seek.cs
@@ -1,0 +1,310 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.IO;
+
+namespace Tyflopodcast {
+
+internal static class Mp3Seek {
+
+	internal sealed class Info {
+		public long totalFileBytes;
+		public int audioStartBytes;
+		public long audioBytes;
+		public double durationSeconds;
+		public byte[] toc; // 100 entries (0-255)
+		public int bitrateKbps;
+		public int sampleRate;
+		public int channels;
+	}
+
+	private static readonly HttpClient http = new HttpClient(new HttpClientHandler {
+		AutomaticDecompression = DecompressionMethods.None,
+		UseProxy = false,
+		Proxy = null,
+		AllowAutoRedirect = true
+	}) {
+		Timeout = TimeSpan.FromSeconds(15)
+	};
+
+	internal static bool TryFetchInfo(string url, out Info info) {
+		info = null;
+		if(string.IsNullOrWhiteSpace(url)) return false;
+
+		const int initialRead = 65536;
+		byte[] data;
+		long totalBytes;
+		if(!TryReadRange(url, 0, initialRead-1, out data, out totalBytes)) return false;
+
+		int id3Size = GetId3v2Size(data);
+		if(id3Size >= data.Length) {
+			const int retryRead = 262144;
+			if(!TryReadRange(url, 0, retryRead-1, out data, out totalBytes)) return false;
+			id3Size = GetId3v2Size(data);
+			if(id3Size >= data.Length) return false;
+		}
+
+		if(!TryFindMpegFrame(data, id3Size, out int frameOffset, out Frame frame)) return false;
+
+		Info r = new Info();
+		r.totalFileBytes = totalBytes;
+		r.audioStartBytes = frameOffset;
+		r.sampleRate = frame.sampleRate;
+		r.channels = frame.channels;
+		r.bitrateKbps = frame.bitrateKbps;
+
+		// Try Xing/Info header (preferred, provides TOC + exact duration/bytes)
+		if(TryParseXingHeader(data, frameOffset, frame, out int xingFlags, out int xingFrames, out int xingBytes, out byte[] xingToc)) {
+			if((xingFlags & 0x1) != 0 && xingFrames > 0 && frame.samplesPerFrame > 0 && frame.sampleRate > 0)
+				r.durationSeconds = (double)xingFrames * (double)frame.samplesPerFrame / (double)frame.sampleRate;
+			if((xingFlags & 0x2) != 0 && xingBytes > 0)
+				r.audioBytes = xingBytes;
+			else if(totalBytes > 0 && frameOffset >= 0 && totalBytes > frameOffset)
+				r.audioBytes = totalBytes - frameOffset;
+			if((xingFlags & 0x4) != 0 && xingToc != null && xingToc.Length == 100)
+				r.toc = xingToc;
+		}
+
+		// Fallback duration/bytes if Xing/Info not available
+		if(r.audioBytes <= 0 && totalBytes > 0 && frameOffset >= 0 && totalBytes > frameOffset)
+			r.audioBytes = totalBytes - frameOffset;
+		if(r.durationSeconds <= 0 && r.audioBytes > 0 && r.bitrateKbps > 0)
+			r.durationSeconds = (double)r.audioBytes / ((double)r.bitrateKbps * 1000.0 / 8.0);
+
+		if(r.audioBytes <= 0 || r.durationSeconds <= 0) return false;
+		info = r;
+		return true;
+	}
+
+	internal static long GetFileOffsetForTime(Info info, double seconds) {
+		if(info == null) return 0;
+		if(seconds < 0) seconds = 0;
+		if(info.durationSeconds > 0 && seconds > info.durationSeconds) seconds = info.durationSeconds;
+
+		long audioPos = 0;
+
+		if(info.toc != null && info.toc.Length == 100 && info.durationSeconds > 0 && info.audioBytes > 0) {
+			double percent = seconds / info.durationSeconds; // 0..1
+			double p = percent * 100.0;
+			int idx = (int)Math.Floor(p);
+			if(idx < 0) idx = 0;
+			if(idx > 99) idx = 99;
+			double fract = p - idx;
+			int a = info.toc[idx];
+			int b = (idx < 99) ? info.toc[idx+1] : 256;
+			double tocVal = (double)a + ((double)(b - a) * fract);
+			audioPos = (long)(tocVal / 256.0 * (double)info.audioBytes);
+		}
+		else if(info.durationSeconds > 0 && info.audioBytes > 0) {
+			audioPos = (long)((seconds / info.durationSeconds) * (double)info.audioBytes);
+		}
+		else if(info.bitrateKbps > 0) {
+			audioPos = (long)(seconds * ((double)info.bitrateKbps * 1000.0 / 8.0));
+		}
+
+		if(audioPos < 0) audioPos = 0;
+		if(info.audioBytes > 0 && audioPos > info.audioBytes) audioPos = info.audioBytes;
+		return (long)info.audioStartBytes + audioPos;
+	}
+
+	private static bool TryReadRange(string url, long from, long to, out byte[] data, out long totalBytes) {
+		data = null;
+		totalBytes = -1;
+
+		try {
+			using(var req = new HttpRequestMessage(HttpMethod.Get, url)) {
+				req.Headers.Range = new RangeHeaderValue(from, to);
+				req.Headers.AcceptEncoding.Clear();
+				req.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("identity"));
+				using(var resp = http.Send(req, HttpCompletionOption.ResponseHeadersRead)) {
+					totalBytes = resp.Content.Headers.ContentRange?.Length ?? resp.Content.Headers.ContentLength ?? -1;
+					using(Stream s = resp.Content.ReadAsStream()) {
+						int max = (int)(to - from + 1);
+						byte[] buf = new byte[max];
+						int read = 0;
+						while(read < max) {
+							int n = s.Read(buf, read, max - read);
+							if(n <= 0) break;
+							read += n;
+						}
+						if(read <= 0) return false;
+						if(read != buf.Length) {
+							byte[] tmp = new byte[read];
+							Array.Copy(buf, tmp, read);
+							buf = tmp;
+						}
+						data = buf;
+						return true;
+					}
+				}
+			}
+		} catch {
+			return false;
+		}
+	}
+
+	private static int GetId3v2Size(byte[] data) {
+		if(data == null || data.Length < 10) return 0;
+		if(data[0] != (byte)'I' || data[1] != (byte)'D' || data[2] != (byte)'3') return 0;
+		int ver = data[3];
+		byte flags = data[5];
+		int size = SynchsafeToInt(data, 6);
+		int total = 10 + size;
+		if(ver >= 4 && (flags & 0x10) != 0) total += 10; // footer
+		if(total < 0) total = 0;
+		if(total > data.Length) return total; // may require more data
+		return total;
+	}
+
+	private static int SynchsafeToInt(byte[] data, int offset) {
+		if(data == null || offset < 0 || offset + 4 > data.Length) return 0;
+		return ((data[offset] & 0x7F) << 21) | ((data[offset+1] & 0x7F) << 14) | ((data[offset+2] & 0x7F) << 7) | (data[offset+3] & 0x7F);
+	}
+
+	private struct Frame {
+		public int mpegVersion; // 1,2,25
+		public int layer; // 1,2,3
+		public bool hasCrc;
+		public int bitrateKbps;
+		public int sampleRate;
+		public int channels;
+		public int samplesPerFrame;
+	}
+
+	private static bool TryFindMpegFrame(byte[] data, int start, out int frameOffset, out Frame frame) {
+		frameOffset = -1;
+		frame = new Frame();
+		if(data == null || data.Length < 4) return false;
+		if(start < 0) start = 0;
+		if(start > data.Length - 4) return false;
+
+		for(int i=start; i <= data.Length - 4; ++i) {
+			if(data[i] != 0xFF || (data[i+1] & 0xE0) != 0xE0) continue;
+			if(!TryParseFrameHeader(data, i, out Frame f)) continue;
+			frameOffset = i;
+			frame = f;
+			return true;
+		}
+		return false;
+	}
+
+	private static bool TryParseFrameHeader(byte[] data, int offset, out Frame f) {
+		f = new Frame();
+		if(data == null || offset < 0 || offset + 4 > data.Length) return false;
+
+		byte b1 = data[offset+1];
+		int versionId = (b1 >> 3) & 0x03;
+		int layerId = (b1 >> 1) & 0x03;
+		if(versionId == 1 || layerId == 0) return false; // reserved
+
+		int mpegVersion = versionId == 3 ? 1 : (versionId == 2 ? 2 : 25);
+		int layer = layerId == 3 ? 1 : (layerId == 2 ? 2 : 3);
+		bool hasCrc = (b1 & 0x01) == 0;
+
+		byte b2 = data[offset+2];
+		int bitrateIndex = (b2 >> 4) & 0x0F;
+		int sampleIndex = (b2 >> 2) & 0x03;
+		if(sampleIndex == 3) return false;
+
+		int sampleRate = GetSampleRate(mpegVersion, sampleIndex);
+		int bitrateKbps = GetBitrateKbps(mpegVersion, layer, bitrateIndex);
+		if(sampleRate <= 0 || bitrateKbps <= 0) return false;
+
+		byte b3 = data[offset+3];
+		int channelMode = (b3 >> 6) & 0x03;
+		int channels = channelMode == 3 ? 1 : 2;
+
+		int samplesPerFrame = GetSamplesPerFrame(mpegVersion, layer);
+		if(samplesPerFrame <= 0) return false;
+
+		f.mpegVersion = mpegVersion;
+		f.layer = layer;
+		f.hasCrc = hasCrc;
+		f.bitrateKbps = bitrateKbps;
+		f.sampleRate = sampleRate;
+		f.channels = channels;
+		f.samplesPerFrame = samplesPerFrame;
+		return true;
+	}
+
+	private static int GetSamplesPerFrame(int mpegVersion, int layer) {
+		if(layer == 1) return 384;
+		if(layer == 2) return 1152;
+		// layer 3
+		return mpegVersion == 1 ? 1152 : 576;
+	}
+
+	private static int GetSampleRate(int mpegVersion, int index) {
+		switch(mpegVersion) {
+			case 1:
+				return index == 0 ? 44100 : (index == 1 ? 48000 : 32000);
+			case 2:
+				return index == 0 ? 22050 : (index == 1 ? 24000 : 16000);
+			case 25:
+				return index == 0 ? 11025 : (index == 1 ? 12000 : 8000);
+			default:
+				return 0;
+		}
+	}
+
+	private static int GetBitrateKbps(int mpegVersion, int layer, int index) {
+		if(index <= 0 || index >= 15) return 0;
+
+		// Tables are in kbps.
+		if(layer == 1) {
+			int[] v1 = {0,32,64,96,128,160,192,224,256,288,320,352,384,416,448,0};
+			int[] v2 = {0,32,48,56,64,80,96,112,128,144,160,176,192,224,256,0};
+			return mpegVersion == 1 ? v1[index] : v2[index];
+		}
+		if(layer == 2) {
+			int[] v1 = {0,32,48,56,64,80,96,112,128,160,192,224,256,320,384,0};
+			int[] v2 = {0,8,16,24,32,40,48,56,64,80,96,112,128,144,160,0};
+			return mpegVersion == 1 ? v1[index] : v2[index];
+		}
+		// layer 3
+		int[] l3v1 = {0,32,40,48,56,64,80,96,112,128,160,192,224,256,320,0};
+		int[] l3v2 = {0,8,16,24,32,40,48,56,64,80,96,112,128,144,160,0};
+		return mpegVersion == 1 ? l3v1[index] : l3v2[index];
+	}
+
+	private static bool TryParseXingHeader(byte[] data, int frameOffset, Frame frame, out int flags, out int frames, out int bytes, out byte[] toc) {
+		flags = 0;
+		frames = 0;
+		bytes = 0;
+		toc = null;
+
+		if(frame.layer != 3) return false;
+
+		int sideInfoSize;
+		if(frame.mpegVersion == 1)
+			sideInfoSize = frame.channels == 1 ? 17 : 32;
+		else
+			sideInfoSize = frame.channels == 1 ? 9 : 17;
+
+		int xingOffset = frameOffset + 4 + (frame.hasCrc ? 2 : 0) + sideInfoSize;
+		if(xingOffset < 0 || xingOffset + 8 > data.Length) return false;
+
+		string tag = "" + (char)data[xingOffset] + (char)data[xingOffset+1] + (char)data[xingOffset+2] + (char)data[xingOffset+3];
+		if(tag != "Xing" && tag != "Info") return false;
+
+		int p = xingOffset + 4;
+		flags = ReadBE32(data, p); p += 4;
+		if((flags & 0x1) != 0) { frames = ReadBE32(data, p); p += 4; }
+		if((flags & 0x2) != 0) { bytes = ReadBE32(data, p); p += 4; }
+		if((flags & 0x4) != 0) {
+			if(p + 100 > data.Length) return false;
+			toc = new byte[100];
+			Array.Copy(data, p, toc, 0, 100);
+			p += 100;
+		}
+
+		return true;
+	}
+
+	private static int ReadBE32(byte[] data, int offset) {
+		if(data == null || offset < 0 || offset + 4 > data.Length) return 0;
+		return (data[offset] << 24) | (data[offset+1] << 16) | (data[offset+2] << 8) | data[offset+3];
+	}
+}
+}

--- a/src/view_player.cs
+++ b/src/view_player.cs
@@ -124,6 +124,7 @@ btn_play.Text = "P&lay/Pauza";
 btn_play.Size = new Size(100, 40);
 btn_play.Location = new Point(20, 240);
 btn_play.Click += (sender, e) => controller.TogglePlayback();
+btn_play.KeyDown += TBKeyDown;
 this.Controls.Add(btn_play);
 
 btn_bookmarks = new Button();
@@ -131,6 +132,7 @@ btn_bookmarks.Text = "&Zakładki";
 btn_bookmarks.Size = new Size(100, 40);
 btn_bookmarks.Location = new Point(140, 240);
 btn_bookmarks.Click += (sender, e) => controller.Bookmarks(podcast, tb_timer.Value);
+btn_bookmarks.KeyDown += TBKeyDown;
 this.Controls.Add(btn_bookmarks);
 
 btn_download = new Button();
@@ -138,6 +140,7 @@ btn_download.Text = "Po&bierz";
 btn_download.Size = new Size(100, 40);
 btn_download.Location = new Point(260, 240);
 btn_download.Click += (sender, e) => controller.DownloadPodcast(podcast);
+btn_download.KeyDown += TBKeyDown;
 this.Controls.Add(btn_download);
 
 btn_comments = new Button();
@@ -145,6 +148,7 @@ btn_comments.Text = "Pokaż &komentarze";
 btn_comments.Size = new Size(100, 40);
 btn_comments.Location = new Point(380, 240);
 btn_comments.Click += (sender, e) => controller.ShowComments(podcast, true);
+btn_comments.KeyDown += TBKeyDown;
 this.Controls.Add(btn_comments);
 
 btn_close = new Button();
@@ -152,6 +156,7 @@ btn_close.Text = "Zamknij";
 btn_close.Size = new Size(100, 40);
 btn_close.Location = new Point(500, 240);
 btn_close.Click += (sender, e) => this.Close();
+btn_close.KeyDown += TBKeyDown;
 this.Controls.Add(btn_close);
 
 this.CancelButton = btn_close;;
@@ -172,6 +177,12 @@ break;
 }
 
 public void TBKeyDown(Object sender, KeyEventArgs e) {
+if (e.Control && e.KeyCode == Keys.Home) {
+controller.RestartFromBeginning();
+e.Handled = true;
+e.SuppressKeyPress = true;
+return;
+}
 if (e.KeyCode == Keys.Space)
 controller.TogglePlayback();
 if(sender==(Object)lst_chapters && e.KeyCode == Keys.Enter) {
@@ -186,11 +197,14 @@ tb_timer.Update();
 UpdatePosition();
 }
 
-public void SetPosition(double position) {
-tb_timer.Value = (int)position;
-tb_timer.Update();
-UpdatePosition();
-}
+	public void SetPosition(double position) {
+	int v = (int)position;
+	if(v<tb_timer.Minimum) v=tb_timer.Minimum;
+	if(v>tb_timer.Maximum) v=tb_timer.Maximum;
+	tb_timer.Value = v;
+	tb_timer.Update();
+	UpdatePosition();
+	}
 
 private string FormatTime(int tim) {
 int hr, min, sec;

--- a/src/view_sbc_tyflotrackbar.cs
+++ b/src/view_sbc_tyflotrackbar.cs
@@ -47,11 +47,11 @@ return this.Value=Math.Min(this.Value + this.SmallChange, this.Maximum);
 }
 public int SmallDown() {
 return this.Value = Math.Max(this.Value - this.SmallChange, this.Minimum);
-}
-public int LargeUp () {
-return Math.Min(this.Value + this.LargeChange, this.Maximum);
-}
-public int LargeDown() {
-return this.Value = Math.Max(this.Value - this.LargeChange, this.Minimum);
-}
-}
+	}
+	public int LargeUp () {
+	return this.Value = Math.Min(this.Value + this.LargeChange, this.Maximum);
+	}
+	public int LargeDown() {
+	return this.Value = Math.Max(this.Value - this.LargeChange, this.Minimum);
+	}
+	}

--- a/src/view_waiter.cs
+++ b/src/view_waiter.cs
@@ -46,14 +46,26 @@ this.Controls.Add(btn_cancel);
 this.CancelButton = btn_cancel;
 }
 
-public void SetStatus(String t) {
-lb_status.Text=t;
-lb_status.Update();
-}
+	public void SetStatus(String t) {
+	if(IsDisposed) return;
+	if(InvokeRequired) {
+	BeginInvoke(new Action<String>(SetStatus), t);
+	return;
+	}
+	lb_status.Text=t;
+	lb_status.Update();
+	}
 
-public void SetPercentage(int p) {
-pb_percentage.Value=p;
-pb_percentage.Update();
-}
+	public void SetPercentage(int p) {
+	if(IsDisposed) return;
+	if(InvokeRequired) {
+	BeginInvoke(new Action<int>(SetPercentage), p);
+	return;
+	}
+	if(p<pb_percentage.Minimum) p=pb_percentage.Minimum;
+	if(p>pb_percentage.Maximum) p=pb_percentage.Maximum;
+	pb_percentage.Value=p;
+	pb_percentage.Update();
+	}
 }
 }


### PR DESCRIPTION
## Podsumowanie
- Zapis pozycji odtwarzania per podcast i per plik lokalny (w `internal.dat`) + automatyczne wznawianie po ponownym otwarciu.
- Czyszczenie pozycji, gdy użytkownik jest w ostatnich ~30 sekundach odcinka; skrót `Ctrl+Home` restartuje od początku.
- Szybkie wznawianie/przewijanie w dużych zdalnych MP3 przez `HTTP Range` (mapowanie czas → offset pliku na podstawie nagłówka MP3 `Xing/Info`/TOC), zamiast buforowania od 0.
- Poprawki UX/stabilności: `PageUp` na suwaku czasu, clamp wartości suwaka (brak crasha), wątkowo-bezpieczne aktualizacje okna „Buforowanie…”.

## Dlaczego
Wznawianie oraz przewijanie w zdalnych podcastach potrafiło wymagać długiego buforowania od początku (a przy wcześniejszej próbie „offsetu” zdarzały się błędy/skoki). Ten PR dodaje trwałe wznawianie i umożliwia szybkie przeskakiwanie po czasie bez ściągania pliku od 0, jeśli serwer wspiera Range.

## Jak przetestować
1. Odtwórz podcast, zamknij odtwarzacz, otwórz go ponownie → powinien automatycznie wznowić w ostatnim miejscu.
2. Przewiń blisko końca (ostatnie ~30s), zamknij i otwórz ponownie → pozycja powinna być wyczyszczona (start od początku).
3. W odtwarzaczu wciśnij `Ctrl+Home` → odtwarzanie startuje od 0.
4. Na dużym zdalnym odcinku ustaw daleką pozycję / wybierz rozdział → start powinien być szybki (Range seek), bez długiego buforowania od początku.
5. Sprawdź `PageUp`/`PageDown` na suwaku czasu → oba klawisze powinny działać spójnie.

## Ryzyko / uwagi
- Pozycje są zapisywane w `%LOCALAPPDATA%\\tyflopodcast\\internal.dat` (wstecznie kompatybilne rozszerzenie pliku; `db.dat` nadal bywa nadpisywane przy aktualizacji bazy).
- Seek przez Range zależy od wsparcia `Accept-Ranges` po stronie serwera i obecności nagłówka MP3 `Xing/Info`; w pozostałych przypadkach zostaje dotychczasowe zachowanie (buforowanie).
